### PR TITLE
Update actions and pkgdown site

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,7 @@
 .travis.yml
 README.Rmd
+README.qmd
+^.*\.Rproj$
+^\.Rproj\.user$
+^\.github$
+^\._pkgdown\.yml$

--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,0 +1,3 @@
+*.html
+R-version
+*.Rds

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -31,7 +31,7 @@ jobs:
           - {os: windows-latest, r: 'devel'}
           - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: 'oldrel'}
-          # - {os: macOS-latest, r: 'devel'}
+          - {os: macOS-latest, r: 'devel'}
           - {os: macOS-latest, r: 'release'}
           - {os: macOS-latest, r: 'oldrel'}
           - {os: ubuntu-latest, r: 'release'}

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -1,0 +1,62 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# NOTE: This workflow is overkill for most R packages and
+# check-standard.yaml is likely a better choice.
+# usethis::use_github_action("check-standard") will install it.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    - cron:  '30 12 * * 3,6'
+  repository_dispatch:
+    types: [trigger-check-workflow]
+  workflow_dispatch:
+
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: windows-latest, r: 'devel'}
+          - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: 'oldrel'}
+          # - {os: macOS-latest, r: 'devel'}
+          - {os: macOS-latest, r: 'release'}
+          - {os: macOS-latest, r: 'oldrel'}
+          - {os: ubuntu-latest, r: 'release'}
+          - {os: ubuntu-latest, r: 'devel'}
+          - {os: ubuntu-latest, r: '4.0'}
+          - {os: ubuntu-latest, r: '3.6'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+

--- a/.github/workflows/rogtemplate-gh-pages.yaml
+++ b/.github/workflows/rogtemplate-gh-pages.yaml
@@ -1,0 +1,53 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+  workflow_dispatch:
+
+name: rogtemplate-gh-pages
+
+jobs:
+  rogtemplate-gh-pages:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            local::.
+            ropengov/rogtemplate
+
+          needs: website
+
+      - name: Build logo if not present and prepare template
+        run: |
+          # Check that logo is not present
+          if (isFALSE(file.exists(file.path("man", "figures", "logo.png")) ||
+            file.exists(file.path("man", "figures", "logo.png")))) {
+            rogtemplate::rog_logo()
+          } else {
+
+            message("The package already has a logo")
+          }
+
+          rogtemplate::rog_add_template_pkgdown()
+
+        shell: Rscript {0}
+
+      - name: Deploy package
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.quarto/
+.Rproj.user

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: r
-sudo: required
-notifications:
-  email:
-    on_failure: change


### PR DESCRIPTION
Related with #8 

This PR adds actions for testing on the following platforms;

```
        config:
          - {os: windows-latest, r: 'devel'}
          - {os: windows-latest, r: 'release'}
          - {os: windows-latest, r: 'oldrel'}
          # - {os: macOS-latest, r: 'devel'}
          - {os: macOS-latest, r: 'release'}
          - {os: macOS-latest, r: 'oldrel'}
          - {os: ubuntu-latest, r: 'release'}
          - {os: ubuntu-latest, r: 'devel'}
          - {os: ubuntu-latest, r: '4.0'}
          - {os: ubuntu-latest, r: '3.6'}
```

So far eveything is working (back to **R 3.6**) as there is no really a test suite.

Additionally I added an action for building a pkgdown site with **rogtemplate**, see https://ropengov.github.io/rogtemplate/#option-a-deploy-using-github-actions 